### PR TITLE
Adding post-merge git hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ src/*.egg-info
 .project
 .pydevproject
 .pydevproject.bak
+
+#Ignore githooks

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -44,7 +44,7 @@ source-directory = etc/templates
 
 [start-django-project]
 recipe = plone.recipe.command
-command = bin/python etc/bin/django-admin.py startproject ${project:project-name} src/; cp etc/templates/test_settings.py src/${project:project-name}/; cp etc/templates/dev_settings.py src/${project:project-name}/; rm src/manage.py
+command = bin/python etc/bin/django-admin.py startproject ${project:project-name} src/; cp etc/templates/test_settings.py src/${project:project-name}/; cp etc/templates/dev_settings.py src/${project:project-name}/; rm src/manage.py; cp post-merge .git/hooks/
 
 [versions]
 Django = 1.5.5

--- a/post-merge
+++ b/post-merge
@@ -9,6 +9,5 @@ check_run() {
 }
 
 
-check_run bower.json "echo *****************Bower file changed. You might have to Run bower install"
 check_run buildout.cfg "echo *****************Buildout config file changed. You might have to Run bin/buildout"
 check_run setup.py "echo *****************setup.py file changed. You might have to Run bin/buildout"

--- a/post-merge
+++ b/post-merge
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# git hook to run a command after `git pull` if a specified file was changed
+
+changed_files="$(git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD)"
+
+check_run() {
+	echo "$changed_files" | grep --quiet "$1" && eval "$2"
+}
+
+
+check_run bower.json "echo *****************Bower file changed. You might have to Run bower install"
+check_run buildout.cfg "echo *****************Buildout config file changed. You might have to Run bin/buildout"
+check_run setup.py "echo *****************setup.py file changed. You might have to Run bin/buildout"


### PR DESCRIPTION
This checks the diff between some files when you do git pull or git merge and prompts developers to run certain command.
The files it checks are buildout.cfg and setup.py.
